### PR TITLE
fix!: `HubSpotSubError` pointer in `HubSpotSubErrors`

### DIFF
--- a/error.go
+++ b/error.go
@@ -68,7 +68,7 @@ func (e *HubSpotError) Unwrap() error {
 // The error message is a concatenation of all the sub-errors' messages.
 //
 // It may be unwrapped to get the list of sub-errors excluding the first one.
-type HubSpotSubErrors []HubSpotSubError
+type HubSpotSubErrors []*HubSpotSubError
 
 func (e HubSpotSubErrors) Error() string {
 	var message strings.Builder
@@ -121,4 +121,31 @@ func HubSpotResponseError(resp *http.Response) error {
 		return fmt.Errorf("decode hubspot error: %w", err)
 	}
 	return hsErr
+}
+
+func IsHubSpotError(err error) bool {
+	_, ok := err.(*HubSpotError)
+	return ok
+}
+
+func IsHubSpotSubErrors(err error) bool {
+	_, ok := err.(HubSpotSubErrors)
+	if ok {
+		return true
+	}
+	ep := &HubSpotSubErrors{}
+	return errors.As(err, &ep)
+}
+
+func IsHubSpotSubError(err error) bool {
+	_, ok := err.(*HubSpotSubError)
+	return ok
+}
+
+func IsAnyHubSpotError(err error) bool {
+	switch err.(type) {
+	case *HubSpotError, *HubSpotSubErrors, HubSpotSubErrors, *HubSpotSubError:
+		return true
+	}
+	return false
 }

--- a/error_test.go
+++ b/error_test.go
@@ -30,3 +30,25 @@ func TestHubSpotError(t *testing.T) {
 
 	assert.Nil(t, errors.Unwrap(subErr2))
 }
+
+func TestIsHubSpotError(t *testing.T) {
+	assert.True(t, IsHubSpotError(&HubSpotError{}))
+	assert.False(t, IsHubSpotError(errors.New("not a HubSpotError")))
+	assert.False(t, IsHubSpotError(nil))
+
+	assert.True(t, IsHubSpotSubErrors(&HubSpotSubErrors{}))
+	assert.True(t, IsHubSpotSubErrors(HubSpotSubErrors{}))
+	assert.False(t, IsHubSpotSubErrors(errors.New("not a HubSpotSubErrors")))
+	assert.False(t, IsHubSpotSubErrors(nil))
+
+	assert.True(t, IsHubSpotSubError(&HubSpotSubError{}))
+	assert.False(t, IsHubSpotSubError(errors.New("not a HubSpotSubError")))
+	assert.False(t, IsHubSpotSubError(nil))
+
+	assert.True(t, IsAnyHubSpotError(&HubSpotError{}))
+	assert.True(t, IsAnyHubSpotError(&HubSpotSubErrors{}))
+	assert.True(t, IsAnyHubSpotError(HubSpotSubErrors{}))
+	assert.True(t, IsAnyHubSpotError(&HubSpotSubError{}))
+	assert.False(t, IsAnyHubSpotError(errors.New("not a HubSpotError")))
+	assert.False(t, IsAnyHubSpotError(nil))
+}


### PR DESCRIPTION
`HubSpotSubError` Error method  has pointer receiver, `HubSpotSubErrors` now is a slice of `*HubSpotSubError`.

BREAKING CHANGE: any `HubSpotSubErrors` declared must be updated to be a `[]*HubSpotSubError`